### PR TITLE
allow user to pass list of groups to be mapped to single flag type

### DIFF
--- a/django_auth_adfs/backend.py
+++ b/django_auth_adfs/backend.py
@@ -230,7 +230,9 @@ class AdfsBaseBackend(ModelBackend):
 
             for flag, group in settings.GROUP_TO_FLAG_MAPPING.items():
                 if hasattr(user, flag):
-                    if group in access_token_groups:
+                    if isinstance(group, list) and any(group_list_item in access_token_groups for group_list_item in group):
+                        value = True
+                    elif group in access_token_groups:
                         value = True
                     else:
                         value = False


### PR DESCRIPTION
No change to original functionality and it adds the ability to pass in a list to GROUP_TO_FLAG_MAPPING.

This is useful for companies like mine that have many different managed security groups and may need to associate more than one group with a single flag. 

example usage:
` {"GROUP_TO_FLAG_MAPPING": { 
"is_staff": ["ALL_RWILLIAMS_DIRECT_EMPLOYEES", "ALL_SEDWARDS_DIRECT_EMPLOYEES"],
"is_superuser": "APP_ADMIN_GROUP"}}`
