### PR TITLE
PyJWT version 2.0.0 dropped "ExpiredSignature" as an alias for "ExpiredSignatureError", which breaks AdfsBaseBackend.validate_access_token()

### DIFF
--- a/django_auth_adfs/backend.py
+++ b/django_auth_adfs/backend.py
@@ -11,6 +11,10 @@ from django_auth_adfs.config import provider_config, settings
 
 logger = logging.getLogger("django_auth_adfs")
 
+# Monkey-patching PyJWT because version 2.0.0 dropped "ExpiredSignature" as an alias for "ExpiredSignatureError"
+if not hasattr(jwt, "ExpiredSignature"):
+    jwt.ExpiredSignature = jwt.ExpiredSignatureError
+
 
 class AdfsBaseBackend(ModelBackend):
     def exchange_auth_code(self, authorization_code, request):


### PR DESCRIPTION
PyJWT version 2.0.0 dropped "ExpiredSignature" as an alias for "ExpiredSignatureError", so I monkey-patched it back to avoid an AttributeError that was being raised inside AdfsBaseBackend.validate_access_token()