### PR TITLE
Remove deprecated method from urls.py

### DIFF
--- a/django_auth_adfs/urls.py
+++ b/django_auth_adfs/urls.py
@@ -1,13 +1,13 @@
-from django.conf.urls import url
+from django.conf.urls import re_path
 
 from django_auth_adfs import views
 
 app_name = "django_auth_adfs"
 
 urlpatterns = [
-    url(r'^callback$', views.OAuth2CallbackView.as_view(), name='callback'),
-    url(r'^login$', views.OAuth2LoginView.as_view(), name='login'),
-    url(r'^login_no_sso$', views.OAuth2LoginNoSSOView.as_view(), name='login-no-sso'),
-    url(r'^login_force_mfa$', views.OAuth2LoginForceMFA.as_view(), name='login-force-mfa'),
-    url(r'^logout$', views.OAuth2LogoutView.as_view(), name='logout'),
+    re_path(r'^callback$', views.OAuth2CallbackView.as_view(), name='callback'),
+    re_path(r'^login$', views.OAuth2LoginView.as_view(), name='login'),
+    re_path(r'^login_no_sso$', views.OAuth2LoginNoSSOView.as_view(), name='login-no-sso'),
+    re_path(r'^login_force_mfa$', views.OAuth2LoginForceMFA.as_view(), name='login-force-mfa'),
+    re_path(r'^logout$', views.OAuth2LogoutView.as_view(), name='logout'),
 ]


### PR DESCRIPTION
`url()` is deprecated since Django version 3.1. A quick approach is to use the equivalent `re_path()` alias.