### PR TITLE
Allow username matching field to be configured.

### DIFF
--- a/django_auth_adfs/backend.py
+++ b/django_auth_adfs/backend.py
@@ -121,10 +121,10 @@ class AdfsBaseBackend(ModelBackend):
         """
         # Create the user
         username_claim = settings.USERNAME_CLAIM
+        usermodel = get_user_model()
         if settings.USERNAME_MATCH:
             username_match = settings.USERNAME_MATCH
         else:
-            usermodel = get_user_model()
             username_match = usermodel.USERNAME_FIELD
         userdata = {username_match: claims[username_claim]}
 

--- a/django_auth_adfs/backend.py
+++ b/django_auth_adfs/backend.py
@@ -124,8 +124,8 @@ class AdfsBaseBackend(ModelBackend):
         if settings.USERNAME_MATCH:
             username_match = settings.USERNAME_MATCH
         else:
+            usermodel = get_user_model()
             username_match = usermodel.USERNAME_FIELD
-        usermodel = get_user_model()
         userdata = {username_match: claims[username_claim]}
 
         try:

--- a/django_auth_adfs/backend.py
+++ b/django_auth_adfs/backend.py
@@ -121,8 +121,12 @@ class AdfsBaseBackend(ModelBackend):
         """
         # Create the user
         username_claim = settings.USERNAME_CLAIM
+        if settings.USERNAME_MATCH:
+            username_match = settings.USERNAME_MATCH
+        else:
+            username_match = usermodel.USERNAME_FIELD
         usermodel = get_user_model()
-        userdata = {usermodel.USERNAME_FIELD: claims[username_claim]}
+        userdata = {username_match: claims[username_claim]}
 
         try:
             user = usermodel.objects.get(**userdata)

--- a/django_auth_adfs/config.py
+++ b/django_auth_adfs/config.py
@@ -69,6 +69,7 @@ class Settings(object):
         self.SERVER = None  # Required
         self.TENANT_ID = None  # Required
         self.TIMEOUT = 5
+        self.USERNAME_MATCH = None
         self.USERNAME_CLAIM = "winaccountname"
         self.JWT_LEEWAY = 0
         self.CUSTOM_FAILED_RESPONSE_VIEW = lambda request, error_message, status: render(


### PR DESCRIPTION
Hello. Our Azure AD does not have the winaccountname or sAMAccountName available to match against username in our Django User table. We do have fields that can be matched, one being the SID. This patch allows the match field to be configured so you can lookup the Django User based on what claims you have available. Hope it's useful.