### PR TITLE
Allowing a second USERNAME_CLAIM to allow guest users to log in

### DIFF
--- a/django_auth_adfs/backend.py
+++ b/django_auth_adfs/backend.py
@@ -121,11 +121,16 @@ class AdfsBaseBackend(ModelBackend):
         """
         # Create the user
         username_claim = settings.USERNAME_CLAIM
+        second_username_claim = settings.SECOND_USERNAME_CLAIM
         usermodel = get_user_model()
 
-        if not claims.get(username_claim):
-            logger.error("User claim's doesn't have the claim '%s' in his claims: %s" % (username_claim, claims))
+        if not claims.get(username_claim) and not claims.get(second_username_claim):
+            logger.error("User claim's doesn't have the claim's '%s' or '%s' in his claims: %s" % (username_claim, second_username_claim, claims))
             raise PermissionDenied
+        
+        # If there is no first username_claim we override it with the second wich is checked that exists
+        if not claims.get(username_claim):
+            username_claim = second_username_claim
         userdata = {usermodel.USERNAME_FIELD: claims[username_claim]}
 
         try:

--- a/django_auth_adfs/config.py
+++ b/django_auth_adfs/config.py
@@ -70,6 +70,7 @@ class Settings(object):
         self.TENANT_ID = None  # Required
         self.TIMEOUT = 5
         self.USERNAME_CLAIM = "winaccountname"
+        self.SECOND_USERNAME_CLAIM = "email"
         self.JWT_LEEWAY = 0
         self.CUSTOM_FAILED_RESPONSE_VIEW = lambda request, error_message, status: render(
             request, 'django_auth_adfs/login_failed.html', {'error_message': error_message}, status=status


### PR DESCRIPTION
I check if there is a SECOND_USERNAME_CLAIM in the claims that AD returns and if it does and the USERNAME_CLAIM is not in the claims we switch the USERNAME_CLAIM to the SECOND_USERNAME_CLAIM.

This way we can allow guest user's to log in if they are previusly invited to the AD (for example via Teams invitation)