### PR TITLE
Replace codecov workflow

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -1,7 +1,7 @@
 name: coverage
 
 on:
-  pull_request: 
+  pull_request:
   push:
     branches:
       - master
@@ -19,9 +19,8 @@ jobs:
       with:
         python-version: 3.9
     - name: Install poetry
-      uses: snok/install-poetry@v1.1.1
+      uses: snok/install-poetry@v1
       with:
-        virtualenvs-create: true
         virtualenvs-in-project: true
     - name: Load cached venv
       id: cached-poetry-dependencies
@@ -32,12 +31,12 @@ jobs:
     - name: Install dependencies
       run: poetry install
       if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
-    - name: Test with pytest
+    - name: Test with Django test
       run: |
         poetry run coverage run manage.py test -v 2
         poetry run coverage xml
     - name: Upload coverage
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v2
       with:
         file: ./coverage.xml
         fail_ci_if_error: true


### PR DESCRIPTION
Meant to replace this workflow, but since the package runs tests with `manage.py test` I guess we can't?