### PR TITLE
method_whitelist is deprecated in urllib3 in favour of allowed_methods

### DIFF
--- a/django_auth_adfs/config.py
+++ b/django_auth_adfs/config.py
@@ -180,7 +180,7 @@ class ProviderConfig(object):
         self.end_session_endpoint = None
         self.issuer = None
 
-        method_whitelist = frozenset([
+        allowed_methods = frozenset([
             'HEAD', 'GET', 'PUT', 'DELETE', 'OPTIONS', 'TRACE', 'POST'
         ])
 
@@ -189,7 +189,7 @@ class ProviderConfig(object):
             read=settings.RETRIES,
             connect=settings.RETRIES,
             backoff_factor=0.3,
-            method_whitelist=method_whitelist
+            allowed_methods=allowed_methods
         )
         self.session = requests.Session()
         adapter = requests.adapters.HTTPAdapter(max_retries=retry)


### PR DESCRIPTION
Created this pull request for issue https://github.com/snok/django-auth-adfs/issues/187

There was a deprecation warning for using 'method_whitelist' with Retry from urllib3.

```
/django_auth_adfs/config.py:192
DeprecationWarning: Using 'method_whitelist' with Retry is deprecated and will be removed in v2.0. Use 'allowed_methods' instead
```

For more info, have a look at their documentation / code:
- https://pypi.org/project/urllib3/1.26.0/
- https://github.com/urllib3/urllib3/blob/1.26.7/src/urllib3/util/retry.py#L241
- https://github.com/urllib3/urllib3/blob/1.26.7/src/urllib3/util/retry.py#L252

In this PR I've replaced method_whitelist with allowed_methods