### PR TITLE
Upgrade urllib3 to 1.26.7

### DIFF
--- a/django_auth_adfs/config.py
+++ b/django_auth_adfs/config.py
@@ -180,7 +180,7 @@ class ProviderConfig(object):
         self.end_session_endpoint = None
         self.issuer = None
 
-        method_whitelist = frozenset([
+        allowed_methods = frozenset([
             'HEAD', 'GET', 'PUT', 'DELETE', 'OPTIONS', 'TRACE', 'POST'
         ])
 
@@ -189,7 +189,7 @@ class ProviderConfig(object):
             read=settings.RETRIES,
             connect=settings.RETRIES,
             backoff_factor=0.3,
-            method_whitelist=method_whitelist
+            allowed_methods=allowed_methods
         )
         self.session = requests.Session()
         adapter = requests.adapters.HTTPAdapter(max_retries=retry)

--- a/poetry.lock
+++ b/poetry.lock
@@ -208,7 +208,7 @@ python-versions = ">=3.5"
 
 [[package]]
 name = "urllib3"
-version = "1.26.2"
+version = "1.26.7"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 category = "main"
 optional = false
@@ -388,6 +388,6 @@ sqlparse = [
     {file = "sqlparse-0.4.1.tar.gz", hash = "sha256:0f91fd2e829c44362cbcfab3e9ae12e22badaa8a29ad5ff599f9ec109f0454e8"},
 ]
 urllib3 = [
-    {file = "urllib3-1.26.2-py2.py3-none-any.whl", hash = "sha256:d8ff90d979214d7b4f8ce956e80f4028fc6860e4431f731ea4a8c08f23f99473"},
-    {file = "urllib3-1.26.2.tar.gz", hash = "sha256:19188f96923873c92ccb987120ec4acaa12f0461fa9ce5d3d0772bc965a39e08"},
+    {file = "urllib3-1.26.7-py2.py3-none-any.whl", hash = "sha256:c4fdf4019605b6e5423637e01bc9fe4daef873709a7973e195ceba0a62bbc844"},
+    {file = "urllib3-1.26.7.tar.gz", hash = "sha256:4987c65554f7a2dbf30c18fd48778ef124af6fab771a377103da0585e2336ece"},
 ]


### PR DESCRIPTION
Created this pull request for issue https://github.com/snok/django-auth-adfs/issues/187

There was a deprecation warning for using 'method_whitelist' with Retry from urllib3.

```
/django_auth_adfs/config.py:192
DeprecationWarning: Using 'method_whitelist' with Retry is deprecated and will be removed in v2.0. Use 'allowed_methods' instead
```

For more info, have a look at their documentation / code:
- https://pypi.org/project/urllib3/1.26.0/
- https://github.com/urllib3/urllib3/blob/1.26.7/src/urllib3/util/retry.py#L241
- https://github.com/urllib3/urllib3/blob/1.26.7/src/urllib3/util/retry.py#L252

In this PR I've updated urllib3 to its latest version 1.26.7