### PR TITLE
Correct error message when VERSION is set but not TENANT_ID

### DIFF
--- a/django_auth_adfs/config.py
+++ b/django_auth_adfs/config.py
@@ -135,7 +135,7 @@ class Settings(object):
                                   "last_name": "family_name",
                                   "email": "email"}
         elif "VERSION" in _settings:
-            raise ImproperlyConfigured("The VERSION cannot be set when TENANT_ID is set.")
+            raise ImproperlyConfigured("The VERSION cannot be set when TENANT_ID is not set.")
 
         # Overwrite defaults with user settings
         for setting, value in _settings.items():


### PR DESCRIPTION
A tiny fix to the error that is raised when the `VERSION` settings is specified, but not the `TENANT_ID`