### PR TITLE
Add Django 4.0 to test matrix

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -17,22 +17,9 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pip-
             ${{ runner.os }}-
-      - run: python -m pip install flake8  # isort black
+      - run: python -m pip install flake8
       - run: |
           flake8 .
-#          black . --check
-#          isort .
-
-  get-python-versions:
-    runs-on: ubuntu-latest
-    outputs:
-      python-matrix: ${{ steps.get-python-versions-action.outputs.latest-python-versions }}
-    steps:
-    - uses: snok/latest-python-versions@v1
-      id: get-python-versions-action
-      with:
-        min-version: 3.8
-        include-prereleases: true
 
   test:
     needs: [linting, get-python-versions]
@@ -40,8 +27,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ${{ fromJson(needs.set-python-versions.outputs.python-matrix) }}
-        django-version: [ "2.2", "3.0", "3.1", "3.2" ]
+        python-version: [ "3.8", "3.9", "3.10" ]
+        django-version: [ "2.2", "3.0", "3.1", "3.2", "4.0" ]
         drf-version: [ "3.10", "3.11", "3.12" ]
     steps:
       - name: Check out repository

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1,6 +1,10 @@
 name: test
 
-on: pull_request
+on:
+  pull_request:
+  push:
+    branches:
+      - master
 
 jobs:
   linting:


### PR DESCRIPTION
I think adding the `get-python-versions` job can be considered a failed experiment. This replaces it with a hardcoded matrix, and adds Django 4.0 to it.