### PR TITLE
Update docs to show an audience list can be provided 

### DIFF
--- a/docs/settings_ref.rst
+++ b/docs/settings_ref.rst
@@ -8,7 +8,7 @@ Settings Reference
 AUDIENCE
 --------
 * **Default**:
-* **Type**: ``string``
+* **Type**: ``string`` or ``list``
 
 **Required**
 


### PR DESCRIPTION
The underlying Python JWT library [supports validating tokens against a list of audiences](https://pyjwt.readthedocs.io/en/stable/api.html#jwt.decode). Without any code changes, I was able to just pass in a list to the `AUDIENCE` setting, after looking through the JWT library code. It would be nice if these docs showed this is a possible configuration:

```python
AUTH_ADFS = {
    'AUDIENCE': ['xxxxxxxx-xxxx-xxxx-xxxxxxxxxxxx', 'api://xxxxxxxx-xxxx-xxxx-xxxxxxxxxxxx']
}
```