### PR TITLE
Performance updates in self.update_user_groups method

### DIFF
--- a/django_auth_adfs/backend.py
+++ b/django_auth_adfs/backend.py
@@ -227,7 +227,7 @@ class AdfsBaseBackend(ModelBackend):
                                 new_groups.append(group)
                             except ObjectDoesNotExist:
                                 pass
-                user.groups.add(*existing_groups, *new_groups)
+                user.groups.set(list(existing_groups.iterator()) + new_groups)
 
     def update_user_flags(self, user, claims):
         """


### PR DESCRIPTION
Made some very slight performance updates in the self.update_user_groups method. `values_list()` retrieves a subset of data without the overhead of creating model instances