### PR TITLE
Provide optional setting for a proxy

### DIFF
--- a/django_auth_adfs/config.py
+++ b/django_auth_adfs/config.py
@@ -75,6 +75,7 @@ class Settings(object):
         self.CUSTOM_FAILED_RESPONSE_VIEW = lambda request, error_message, status: render(
             request, 'django_auth_adfs/login_failed.html', {'error_message': error_message}, status=status
         )
+        self.PROXIES = None
 
         self.VERSION = 'v1.0'
 
@@ -195,6 +196,8 @@ class ProviderConfig(object):
         adapter = requests.adapters.HTTPAdapter(max_retries=retry)
         self.session.mount('https://', adapter)
         self.session.verify = settings.CA_BUNDLE
+        if hasattr(settings, "PROXIES"):
+            self.session.proxies = settings.PROXIES
 
     def load_config(self):
         # If loaded data is too old, reload it again

--- a/docs/settings_ref.rst
+++ b/docs/settings_ref.rst
@@ -452,3 +452,11 @@ VERSION
 * **Type**: ``string``
 
 Version of the Azure Active Directory endpoint version. By default it is set to ``v1.0``. At the time of writing this documentation, it can also be set to ``v2.0``. For new projects, ``v2.0`` is recommended. ``v1.0`` is kept as a default for backwards compatibility.
+
+PROXIES
+-------
+* **Default**: ``None``
+* **Type**: ``dict``
+
+An optional proxy for all communication with the server. Example: ``{'http': '10.0.0.1', 'https': '10.0.0.2'}``
+Also see the `request docs <https://requests.readthedocs.io/en/v3.0.0/api/#requests.Session.proxies>`__.

--- a/docs/settings_ref.rst
+++ b/docs/settings_ref.rst
@@ -459,4 +459,4 @@ PROXIES
 * **Type**: ``dict``
 
 An optional proxy for all communication with the server. Example: ``{'http': '10.0.0.1', 'https': '10.0.0.2'}``
-Also see the `request docs <https://requests.readthedocs.io/en/v3.0.0/api/#requests.Session.proxies>`__.
+See the `requests documentation <https://requests.readthedocs.io/en/v3.0.0/api/#requests.Session.proxies>`__ for more information.

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -6,6 +6,7 @@ from django.test import TestCase, SimpleTestCase, override_settings
 from mock import patch
 from django_auth_adfs.config import django_settings
 from django_auth_adfs.config import Settings
+from django_auth_adfs.config import ProviderConfig
 from .custom_config import Settings as CustomSettings
 
 
@@ -94,6 +95,17 @@ class SettingsTests(TestCase):
         with patch("django_auth_adfs.config.django_settings", settings):
             with self.assertRaises(ImproperlyConfigured):
                 Settings()
+
+    def test_configured_proxy(self):
+        settings = Settings()
+        settings.PROXIES = {'http': '10.0.0.1'}
+        with patch("django_auth_adfs.config.settings", settings):
+            provider_config = ProviderConfig()
+            self.assertEqual(provider_config.session.proxies, {'http': '10.0.0.1'})
+
+    def test_no_configured_proxy(self):
+        provider_config = ProviderConfig()
+        self.assertIsNone(provider_config.session.proxies)
 
 
 class CustomSettingsTests(SimpleTestCase):


### PR DESCRIPTION
We ran into the same problem as reported in #217 and followed up on the proposed implementation.

I am not too confident about the test, as mocking a "singleton" does not really prove that the setting is properly picked up (we are testing the mock and not the actual object) - but it is locally consistent. 

This fix is also running on a development host and it does the trick.