### PR TITLE
Reduce the number of SQL queries in updates of groups

### DIFF
--- a/django_auth_adfs/backend.py
+++ b/django_auth_adfs/backend.py
@@ -4,7 +4,8 @@ import jwt
 from django.contrib.auth import get_user_model
 from django.contrib.auth.backends import ModelBackend
 from django.contrib.auth.models import Group
-from django.core.exceptions import ImproperlyConfigured, ObjectDoesNotExist, PermissionDenied
+from django.core.exceptions import (ImproperlyConfigured, ObjectDoesNotExist,
+                                    PermissionDenied)
 
 from django_auth_adfs import signals
 from django_auth_adfs.config import provider_config, settings
@@ -322,27 +323,24 @@ class AdfsBaseBackend(ModelBackend):
         """
         if settings.GROUPS_CLAIM is not None:
             # Update the user's group memberships
-            django_groups = [group.name for group in user.groups.all()]
+            user_group_names = user.groups.all().values_list("name", flat=True)
 
-            if sorted(claim_groups) != sorted(django_groups):
-                existing_groups = list(Group.objects.filter(name__in=claim_groups).iterator())
-                existing_group_names = frozenset(group.name for group in existing_groups)
-                new_groups = []
+            if sorted(claim_groups) != sorted(user_group_names):
+                # Get the list of already existing groups in one query
+                existing_claimed_groups = Group.objects.filter(name__in=claim_groups)
+                existing_claimed_group_names = (
+                    group.name for group in existing_claimed_groups
+                )
+
+                new_claimed_group_names = (name for name in claim_groups if name not in existing_claimed_group_names)
                 if settings.MIRROR_GROUPS:
-                    new_groups = [
+                    new_claimed_groups = [
                         Group.objects.get_or_create(name=name)[0]
-                        for name in claim_groups
-                        if name not in existing_group_names
+                        for name in new_claimed_group_names
                     ]
                 else:
-                    for name in claim_groups:
-                        if name not in existing_group_names:
-                            try:
-                                group = Group.objects.get(name=name)
-                                new_groups.append(group)
-                            except ObjectDoesNotExist:
-                                pass
-                user.groups.set(existing_groups + new_groups)
+                    new_claimed_groups = Group.objects.filter(name__in=new_claimed_group_names)
+                user.groups.set(tuple(existing_claimed_groups) + tuple(new_claimed_groups))
 
     def update_user_flags(self, user, claims, claim_groups):
         """


### PR DESCRIPTION
After having read the PR #230, my initial intention was to focus on SQL queries. I think it's more efficient to reduce the number of SQL queries to speed up the group creation (round-trip latency could be significant with DB).
So my initial patch leveraged `create_bulk` of Django ORM but I found out about the signal issues in #220 and I changed my mind to provide something less intrusive.

I'll be happy to provide a `create_bulk` version if you want.

Changes:
- only one query instead of one for each group when no MIRROR_GROUPS
- the use of iterator() inside a list() creates a useless SQL cursor
- avoid to create Django instances of groups by using values_list()
- replace a frozenset by a tuple
- add test for `MIRROR_GROUPS`

I had to disable Black in my editor to not mess the code ;)