### PR TITLE
feat: Added setting UPN_CLAIM allowing us to match the email instead of username

### DIFF
--- a/django_auth_adfs/config.py
+++ b/django_auth_adfs/config.py
@@ -69,6 +69,7 @@ class Settings(object):
         self.SERVER = None  # Required
         self.TENANT_ID = None  # Required
         self.TIMEOUT = 5
+        self.UPN_CLAIM = None
         self.USERNAME_CLAIM = "winaccountname"
         self.GUEST_USERNAME_CLAIM = None
         self.JWT_LEEWAY = 0
@@ -84,7 +85,14 @@ class Settings(object):
             "CLIENT_ID",
             "RELYING_PARTY_ID",
             "USERNAME_CLAIM",
+            "UPN_CLAIM",
         ]
+
+        # Only one of either UPN_CLAIM or USERNAME_CLAIM is required.
+        if self.UPN_CLAIM:
+            required_settings.remove("USERNAME_CLAIM")
+        else:
+            required_settings.remove("UPN_CLAIM")
 
         deprecated_settings = {
             "AUTHORIZE_PATH": "This setting is automatically loaded from ADFS.",


### PR DESCRIPTION
In our case we do not create new users. Instead, we onboard them previously through a different process and usernames follow a specific pattern instead of email address.

This PR adds the setting `UPN_CLAIM` that can be set to the email field. If this is set, the code will not attempt to match an existing user by username, but by the email field and claims upn instead.

If the user is being created it will still set the username field to the UPN