### PR TITLE
Update drf_urls.py

### DIFF
--- a/django_auth_adfs/drf_urls.py
+++ b/django_auth_adfs/drf_urls.py
@@ -11,4 +11,5 @@ app_name = "rest_framework"
 
 urlpatterns = [
     re_path(r'^login$', views.OAuth2LoginView.as_view(), name='login'),
+    re_path(r'^logout$', views.OAuth2LogoutView.as_view(), name='logout'),
 ]


### PR DESCRIPTION
When using with DRF I was getting
django.urls.exceptions.NoReverseMatch: Reverse for 'logout' not found. 'logout' is not a valid view function or pattern name. 
to cope that I made a fix.