### PR TITLE
RE Issue #300 License Update? 

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,13 +1,12 @@
 Copyright (c) 2016, Joris Beckers
-All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,
 are permitted provided that the following conditions are met:
 
-- Redistributions of source code must retain the above copyright notice, this
+1. Redistributions of source code must retain the above copyright notice, this
   list of conditions and the following disclaimer.
 
-- Redistributions in binary form must reproduce the above copyright notice, this
+2. Redistributions in binary form must reproduce the above copyright notice, this
   list of conditions and the following disclaimer in the documentation and/or
   other materials provided with the distribution.
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -6,7 +6,7 @@ Installation
 Requirements
 ------------
 
-* Python 3.5 and above
+* Python 3.8 and above
 * Django 1.11 and above
 
 You will also need the following:

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -7,7 +7,7 @@ Requirements
 ------------
 
 * Python 3.8 and above
-* Django 1.11 and above
+* Django 3.2 and above
 
 You will also need the following:
 


### PR DESCRIPTION
#300 

* Updated to match BSD-2 Clause License

Retrieved license content from:
https://opensource.org/license/bsd-2-clause/

Also performed the following changes. 
* **linting**

* **Python 3.7 is Out Of Support:**
([Source](https://devguide.python.org/versions/))
Removed references to 3.7 throughout.

* **python 3.11.6 Now being used** -
The 3.11 cache included Python 3.11.5, which caused failure due to python 3.11.6 now being included. Presumably the cache expired during my work. 