### PR TITLE
Upgrade to Django 5

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -30,17 +30,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.7", "3.8", "3.9", "3.10", "3.11" ]
-        django-version: [ "3.2", "4.0", "4.1", "4.2"]
+        python-version: [ "3.8", "3.9", "3.10", "3.11" ]
+        django-version: [ "3.2", "4.0", "4.1", "4.2", "5.0"]
         drf-version: [ "3.11", "3.12", "3.13" ]
         exclude:
-          # Python 3.7 is incompatible with Django v4+
-          - django-version: 4.0
-            python-version: 3.7
-          - django-version: 4.1
-            python-version: 3.7
-          - django-version: 4.2
-            python-version: 3.7
+          # Python 3.8 is incompatible with Django v5+
+          - django-version: 5.0
+            python-version: 3.8
+          # Python 3.9 is incompatible with Django v5+
+          - django-version: 5.0
+            python-version: 3.9
           # Python 3.11 is incompatible with Django <v4.1
           - django-version: 3.2
             python-version: 3.11

--- a/poetry.lock
+++ b/poetry.lock
@@ -2,23 +2,6 @@
 
 [[package]]
 name = "asgiref"
-version = "3.5.2"
-description = "ASGI specs, helper code, and adapters"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "asgiref-3.5.2-py3-none-any.whl", hash = "sha256:1d2880b792ae8757289136f1db2b7b99100ce959b2aa57fd69dab783d05afac4"},
-    {file = "asgiref-3.5.2.tar.gz", hash = "sha256:4a29362a6acebe09bf1d6640db38c1dc3d9217c68e6f9f6204d72667fc19a424"},
-]
-
-[package.dependencies]
-typing-extensions = {version = "*", markers = "python_version < \"3.8\""}
-
-[package.extras]
-tests = ["mypy (>=0.800)", "pytest", "pytest-asyncio"]
-
-[[package]]
-name = "asgiref"
 version = "3.7.2"
 description = "ASGI specs, helper code, and adapters"
 optional = false
@@ -272,26 +255,6 @@ test-randomorder = ["pytest-randomly"]
 
 [[package]]
 name = "django"
-version = "3.2.23"
-description = "A high-level Python Web framework that encourages rapid development and clean, pragmatic design."
-optional = false
-python-versions = ">=3.6"
-files = [
-    {file = "Django-3.2.23-py3-none-any.whl", hash = "sha256:d48608d5f62f2c1e260986835db089fa3b79d6f58510881d316b8d88345ae6e1"},
-    {file = "Django-3.2.23.tar.gz", hash = "sha256:82968f3640e29ef4a773af2c28448f5f7a08d001c6ac05b32d02aeee6509508b"},
-]
-
-[package.dependencies]
-asgiref = ">=3.3.2,<4"
-pytz = "*"
-sqlparse = ">=0.2.2"
-
-[package.extras]
-argon2 = ["argon2-cffi (>=19.1.0)"]
-bcrypt = ["bcrypt"]
-
-[[package]]
-name = "django"
 version = "4.2.8"
 description = "A high-level Python web framework that encourages rapid development and clean, pragmatic design."
 optional = false
@@ -460,7 +423,6 @@ files = [
 
 [package.dependencies]
 requests = ">=2.0,<3.0"
-typing-extensions = {version = "*", markers = "python_version < \"3.8\""}
 urllib3 = ">=1.25.10"
 
 [package.extras]
@@ -522,5 +484,5 @@ socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [metadata]
 lock-version = "2.0"
-python-versions = "^3.7"
-content-hash = "6752c55730ad93055a08f2627ea21a5fd0418b17cc39f1f6567f9a0642177c74"
+python-versions = "^3.8"
+content-hash = "63a75fb1d7c73785571c378050b6ff89ab1808c7a533c52fa1b6a07ea931063e"

--- a/poetry.lock
+++ b/poetry.lock
@@ -18,6 +18,23 @@ typing-extensions = {version = "*", markers = "python_version < \"3.8\""}
 tests = ["mypy (>=0.800)", "pytest", "pytest-asyncio"]
 
 [[package]]
+name = "asgiref"
+version = "3.7.2"
+description = "ASGI specs, helper code, and adapters"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "asgiref-3.7.2-py3-none-any.whl", hash = "sha256:89b2ef2247e3b562a16eef663bc0e2e703ec6468e2fa8a5cd61cd449786d4f6e"},
+    {file = "asgiref-3.7.2.tar.gz", hash = "sha256:9e0ce3aa93a819ba5b45120216b23878cf6e8525eb3848653452b4192b92afed"},
+]
+
+[package.dependencies]
+typing-extensions = {version = ">=4", markers = "python_version < \"3.11\""}
+
+[package.extras]
+tests = ["mypy (>=0.800)", "pytest", "pytest-asyncio"]
+
+[[package]]
 name = "backports.zoneinfo"
 version = "0.2.1"
 description = "Backport of the standard library zoneinfo module"
@@ -255,13 +272,13 @@ test-randomorder = ["pytest-randomly"]
 
 [[package]]
 name = "django"
-version = "3.2.15"
+version = "3.2.23"
 description = "A high-level Python Web framework that encourages rapid development and clean, pragmatic design."
 optional = false
 python-versions = ">=3.6"
 files = [
-    {file = "Django-3.2.15-py3-none-any.whl", hash = "sha256:115baf5049d5cf4163e43492cdc7139c306ed6d451e7d3571fe9612903903713"},
-    {file = "Django-3.2.15.tar.gz", hash = "sha256:f71934b1a822f14a86c9ac9634053689279cd04ae69cb6ade4a59471b886582b"},
+    {file = "Django-3.2.23-py3-none-any.whl", hash = "sha256:d48608d5f62f2c1e260986835db089fa3b79d6f58510881d316b8d88345ae6e1"},
+    {file = "Django-3.2.23.tar.gz", hash = "sha256:82968f3640e29ef4a773af2c28448f5f7a08d001c6ac05b32d02aeee6509508b"},
 ]
 
 [package.dependencies]
@@ -275,19 +292,39 @@ bcrypt = ["bcrypt"]
 
 [[package]]
 name = "django"
-version = "4.1"
+version = "4.2.8"
 description = "A high-level Python web framework that encourages rapid development and clean, pragmatic design."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "Django-4.1-py3-none-any.whl", hash = "sha256:031ccb717782f6af83a0063a1957686e87cb4581ea61b47b3e9addf60687989a"},
-    {file = "Django-4.1.tar.gz", hash = "sha256:032f8a6fc7cf05ccd1214e4a2e21dfcd6a23b9d575c6573cacc8c67828dbe642"},
+    {file = "Django-4.2.8-py3-none-any.whl", hash = "sha256:6cb5dcea9e3d12c47834d32156b8841f533a4493c688e2718cafd51aa430ba6d"},
+    {file = "Django-4.2.8.tar.gz", hash = "sha256:d69d5e36cc5d9f4eb4872be36c622878afcdce94062716cf3e25bcedcb168b62"},
 ]
 
 [package.dependencies]
-asgiref = ">=3.5.2,<4"
+asgiref = ">=3.6.0,<4"
 "backports.zoneinfo" = {version = "*", markers = "python_version < \"3.9\""}
-sqlparse = ">=0.2.2"
+sqlparse = ">=0.3.1"
+tzdata = {version = "*", markers = "sys_platform == \"win32\""}
+
+[package.extras]
+argon2 = ["argon2-cffi (>=19.1.0)"]
+bcrypt = ["bcrypt"]
+
+[[package]]
+name = "django"
+version = "5.0"
+description = "A high-level Python web framework that encourages rapid development and clean, pragmatic design."
+optional = false
+python-versions = ">=3.10"
+files = [
+    {file = "Django-5.0-py3-none-any.whl", hash = "sha256:3a9fd52b8dbeae335ddf4a9dfa6c6a0853a1122f1fb071a8d5eca979f73a05c8"},
+    {file = "Django-5.0.tar.gz", hash = "sha256:7d29e14dfbc19cb6a95a4bd669edbde11f5d4c6a71fdaa42c2d40b6846e807f7"},
+]
+
+[package.dependencies]
+asgiref = ">=3.7.0"
+sqlparse = ">=0.3.1"
 tzdata = {version = "*", markers = "sys_platform == \"win32\""}
 
 [package.extras]
@@ -486,4 +523,4 @@ socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.7"
-content-hash = "b65729a07171c40de0221bade9f1883f1c23bb74b3df0fb87a1b7f30edae594d"
+content-hash = "6752c55730ad93055a08f2627ea21a5fd0418b17cc39f1f6567f9a0642177c74"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ classifiers = [
     'Framework :: Django :: 4.0',
     'Framework :: Django :: 4.1',
     'Framework :: Django :: 4.2',
+    'Framework :: Django :: 5.0',
     'Intended Audience :: Developers',
     'Intended Audience :: End Users/Desktop',
     'Operating System :: OS Independent',
@@ -39,7 +40,8 @@ classifiers = [
 python = '^3.7'
 django = [
     { version = '^3', python = '<=3.7' },
-    { version = '^3 || ^4', python = '>=3.8' },
+    { version = '^3 || ^4', python = '>=3.8 <3.10' },
+    { version = '^4 || ^5', python = '>=3.10' },
 ]
 requests = '^1 || ^2'
 urllib3 = '^1.26.0'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,6 @@ classifiers = [
     'License :: OSI Approved :: BSD License',
     'Programming Language :: Python',
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.7',
     'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
@@ -37,9 +36,8 @@ classifiers = [
 ]
 
 [tool.poetry.dependencies]
-python = '^3.7'
+python = '^3.8'
 django = [
-    { version = '^3', python = '<=3.7' },
     { version = '^3 || ^4', python = '>=3.8 <3.10' },
     { version = '^4 || ^5', python = '>=3.10' },
 ]

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -518,7 +518,7 @@ class AuthenticationTests(TestCase):
         from django_auth_adfs.config import django_settings
         settings = deepcopy(django_settings)
         settings.AUTH_ADFS["CREATE_NEW_USERS"] = False
-        with patch("django_auth_adfs.config.django_settings", settings),\
+        with patch("django_auth_adfs.config.django_settings", settings), \
                 patch("django_auth_adfs.backend.settings", Settings()):
             backend = AdfsAuthCodeBackend()
             self.assertRaises(PermissionDenied, backend.authenticate, self.request, authorization_code='testcode')


### PR DESCRIPTION
Creating a PR to start testing of Django 5, resolves [#311](https://github.com/snok/django-auth-adfs/issues/311#issuecomment-1839387718).  Also removes Python 3.7 support as this is no longer available for testing or supported by Python.