### PR TITLE
Allow redirect configuring

### DIFF
--- a/django_auth_adfs/config.py
+++ b/django_auth_adfs/config.py
@@ -64,6 +64,7 @@ class Settings(object):
         self.GROUPS_CLAIM = "group"
         self.LOGIN_EXEMPT_URLS = []
         self.MIRROR_GROUPS = False
+        self.REDIR_URI = None
         self.RELYING_PARTY_ID = None  # Required
         self.RETRIES = 3
         self.SERVER = None  # Required
@@ -91,7 +92,6 @@ class Settings(object):
             "AUTHORIZE_PATH": "This setting is automatically loaded from ADFS.",
             "ISSUER": "This setting is automatically loaded from ADFS.",
             "LOGIN_REDIRECT_URL": "Instead use the standard Django settings with the same name.",
-            "REDIR_URI": "This setting is automatically determined based on the URL configuration of Django.",
             "SIGNING_CERT": "The token signing certificates are automatically loaded from ADFS.",
             "TOKEN_PATH": "This setting is automatically loaded from ADFS.",
         }
@@ -321,7 +321,12 @@ class ProviderConfig(object):
 
     def redirect_uri(self, request):
         self.load_config()
-        return request.build_absolute_uri(reverse("django_auth_adfs:callback"))
+        uri_to_redirect = ""
+        if settings.REDIR_URI:
+            uri_to_redirect = settings.REDIR_URI
+        else:
+            uri_to_redirect = request.build_absolute_uri(reverse("django_auth_adfs:callback"))
+        return uri_to_redirect
 
     def build_authorization_endpoint(self, request, disable_sso=None, force_mfa=False):
         """

--- a/docs/settings_ref.rst
+++ b/docs/settings_ref.rst
@@ -340,6 +340,18 @@ This parameter will create groups from ADFS in the Django database if they do no
 .. IMPORTANT::
     This parameter only has effect if GROUP_CLAIM is set to something other then ``None``.
 
+.. _redir_uri_setting:
+
+REDIR_URI
+----------------
+* **Default**:
+* **Type**: ``string``
+
+Set this if you want to force a redirect_uri, instead of building it automatically.
+
+This can be useful if you rely on a proxy that can't be altered to allow http/https identification, or
+if your application operates behind a gateway that changes the netloc of your uri, which creates an undesired redirect_uri.
+
 .. _relying_party_id_setting:
 
 RELYING_PARTY_ID


### PR DESCRIPTION
Adds a REDIR_URI setting that operates by using it if it exists, else following the existent pattern of `request.build_absolute_uri(reverse("django_auth_adfs:callback"))`

It can be pretty useful in cases where there is a proxy or gateway before the application (where we lose the identification of is_secure). Today, [the suggested fix for this sittuation](https://django-auth-adfs.readthedocs.io/en/latest/faq.html#the-redirect-uri-starts-with-http-while-my-site-is-https-only) is by creating on this proxy/gateway a header with this identification, to be used by SECURE_PROXY_SSL_HEADER. This is not possible in some situations (as was my case on the company I work, where it would require actions of multiple other teams that are responsible for the gateway).

Other problem that is solved by this is when the host/netloc of the request that is used to parse the redirect uri is different from a desired one (due to an app with multiple domain names, proxy/gateway configuration, etc)

This pr has the possibility to solve #327 and #303 