### PR TITLE
#270 - Add middleware to refresh access token 

### DIFF
--- a/django_auth_adfs/config.py
+++ b/django_auth_adfs/config.py
@@ -72,6 +72,7 @@ class Settings(object):
         self.USERNAME_CLAIM = "winaccountname"
         self.GUEST_USERNAME_CLAIM = None
         self.JWT_LEEWAY = 0
+        self.REFRESH_THRESHOLD = timedelta(minutes=5)
         self.CUSTOM_FAILED_RESPONSE_VIEW = lambda request, error_message, status: render(
             request, 'django_auth_adfs/login_failed.html', {'error_message': error_message}, status=status
         )

--- a/django_auth_adfs/middleware.py
+++ b/django_auth_adfs/middleware.py
@@ -63,5 +63,5 @@ def adfs_refresh_middleware(get_response):
             backend = auth.load_backend(backend_str)
             if isinstance(backend, AdfsAuthCodeBackend):
                 backend.process_request(request)
-        return get_response()
+        return get_response(request)
     return middleware

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -35,6 +35,7 @@ MIDDLEWARE = (
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 
+    'django_auth_adfs.middleware.adfs_refresh_middleware',
     'django_auth_adfs.middleware.LoginRequiredMiddleware',
 )
 

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -520,7 +520,7 @@ class AuthenticationTests(TestCase):
         response = self.client.get(reverse('django_auth_adfs:callback'), data={'code': "testcode"})
         self.assertFalse(response.wsgi_request.user.is_anonymous)
         fromisoformat = datetime.fromisoformat
-        with patch('django_auth_adfs.backend.datetime') as dt:
+        with patch('django_auth_adfs.middleware.datetime') as dt:
             dt.fromisoformat = fromisoformat
             dt.now.return_value = datetime.now() + timedelta(hours=1)
             response = self.client.get(reverse('test'))

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,6 +1,9 @@
-from django.urls import include, re_path
+from django.urls import include, re_path, path
+
+from tests.views import TestView
 
 urlpatterns = [
+    path('', TestView.as_view(), name='test'),
     re_path(r'^oauth2/', include('django_auth_adfs.urls')),
     re_path(r'^oauth2/', include('django_auth_adfs.drf_urls')),
 ]

--- a/tests/views.py
+++ b/tests/views.py
@@ -1,2 +1,11 @@
+from django.http import HttpResponse
+from django.views import View
+
+
 def test_failed_response(request, error_message, status):
     pass
+
+
+class TestView(View):
+    def get(self, request):
+        return HttpResponse('okay')


### PR DESCRIPTION
Hi,

as mentioned in #270 , I think this would be a great addition to the library and the other PR ( #278 ) is stale, so I am trying to take this over the finish line.

I tried to address your comments as far as possible.

You mentioned in the review for the stale PR that you would not add the access token to the session "just for the sake" of it.
I left this part of the code intentionally, because I would argue that having access to the access token within the request(-session) is an important feature.
I think the most important use case is to be able to use the access token for subsequent requests on behalf of the user to other services.

In our specific situation, we would like to use django-auth-adfs in a situation, where we have a Django Frontend that needs to  perform the user sign-in (via Azure AD) and then request multiple downstream services on behalf of the user to acquire data to show. As all of these downstream services are in-turn OAuth2 protected, we need to send a valid access token with each request, which is only possible if we can access it outside of the AuthBackend e.g. via the session.

I also checked the solution proposed in #267 but I believe that extending the User model and thus saving the access token in the database leads to a security vulnerability as in this case anyone having access to the database could perform requests on behalf of every logged-in user.

Let's discuss and find a solution :-)