### PR TITLE
docs: add documentation for post_authenticate signal

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -38,6 +38,7 @@ Contents
     settings_ref
     config_guides
     middleware
+    signals
     rest_framework
     demo
     troubleshooting

--- a/docs/signals.rst
+++ b/docs/signals.rst
@@ -1,0 +1,25 @@
+Django Signals
+================
+
+**django-auth-adfs** uses Django `Signals <https://docs.djangoproject.com/en/stable/topics/signals/>`
+to allow the application to listen for and execute custom logic at certain points in the authentication
+process. Currently, the following signals are supported:
+
+* ``post_authenticate``: sent after a user has been authenticated through either the ``AdfsAuthCodeBackend``
+  or the ``AdfsAccessTokenBackend`` (and created in Django, if ``CREATE_NEW_USERS`` is enabled) and
+  after all claims and groups have been mapped. The signal is sent with the user object, the claims
+  dictionary, and the ADFS response as arguments for the signal handler.
+
+To use a signal in your application:
+
+.. code-block:: python
+
+    from django.dispatch import receiver
+    from django_auth_adfs.signals import post_authenticate
+
+
+    @receiver(post_authenticate)
+    def handle_post_authenticate(sender, user, claims, adfs_response, **kwargs):
+        user.do_post_auth_steps(claims, adfs_response)
+
+


### PR DESCRIPTION
I fumbled around for a while trying to figure out how to execute some custom code after a user is created/authenticated via SSO before I found the `post_authenticate` signal in the source code. I didn't see it in the docs, and having it in there would have saved me some time.

I didn't really think it fit into any of the existing sections, but if you'd prefer it to be in there (maybe under installation, I guess?), let me know and I can move it.