### PR TITLE
Support Django 5.2

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   codecov:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   linting:
@@ -31,14 +31,15 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13"]
-        django-version: [ "4.2", "5.0", "5.1"]
+        django-version: [ "4.2", "5.0", "5.1", "5.2"]
         drf-version: ["3.14", "3.15"]
         exclude:
           # Python 3.9 is incompatible with Django v5+
           - django-version: 5.0
             python-version: 3.9
-          # Python 3.9 is incompatible with Django v5+
           - django-version: 5.1
+            python-version: 3.9
+          - django-version: 5.2
             python-version: 3.9
           # Django 4.2 is incompatible with Python 3.13+
           - django-version: 4.2
@@ -62,7 +63,7 @@ jobs:
         if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
       - run: |
           source .venv/bin/activate
-          pip install "Django~=${{ matrix.django-version }}.0"
+          pip install "Django~=${{ matrix.django-version }}.0a1"
           pip install "djangorestframework~=${{ matrix.drf-version }}.0"
       - name: Run tests
         run: |

--- a/README.rst
+++ b/README.rst
@@ -10,8 +10,8 @@ ADFS Authentication for Django
     :target: https://pypi.python.org/pypi/django-auth-adfs#downloads
 .. image:: https://img.shields.io/pypi/djversions/django-auth-adfs.svg
     :target: https://pypi.python.org/pypi/django-auth-adfs
-.. image:: https://codecov.io/github/snok/django-auth-adfs/coverage.svg?branch=master
-    :target: https://codecov.io/github/snok/django-auth-adfs?branch=master
+.. image:: https://codecov.io/github/snok/django-auth-adfs/coverage.svg?branch=main
+    :target: https://codecov.io/github/snok/django-auth-adfs?branch=main
 
 A Django authentication backend for Microsoft ADFS and Azure AD
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,8 +10,8 @@ ADFS Authentication for Django
     :target: https://pypi.python.org/pypi/django-auth-adfs#downloads
 .. image:: https://img.shields.io/pypi/djversions/django-auth-adfs.svg
     :target: https://pypi.python.org/pypi/django-auth-adfs
-.. image:: https://codecov.io/github/snok/django-auth-adfs/coverage.svg?branch=master
-    :target: https://codecov.io/github/snok/django-auth-adfs?branch=master
+.. image:: https://codecov.io/github/snok/django-auth-adfs/coverage.svg?branch=main
+    :target: https://codecov.io/github/snok/django-auth-adfs?branch=main
 
 A Django authentication backend for Microsoft ADFS and Azure AD
 


### PR DESCRIPTION
This adds the `a1` suffix to support installing prereleases when necessary.